### PR TITLE
feat: change return value;change pulumiHome to global

### DIFF
--- a/publish.yaml
+++ b/publish.yaml
@@ -2,7 +2,7 @@ Type: Component
 Name: pulumi-alibaba
 Provider:
   - Alibaba
-Version: 0.0.1
+Version: 0.0.6
 Description: component标准组件starter
 HomePage: https://www.aliyun.com/
 Tags: #标签详情

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ const DEFAULT = {
 };
 
 const SUPPORTED_CLOUD_PLATFORMS = ['alicloud'];
+const PULUMI_INSTALL_FILE_PATH = path.join(__dirname, 'utils/pulumi/install.js');
 
 export default class PulumiComponent {
   @core.HLogger('S-CORE') logger: core.ILogger;
@@ -29,13 +30,13 @@ export default class PulumiComponent {
       this.pulumiHome = DEFAULT.pulumiHome;
       this.pulumiAlreadyExists = true;
     } else {
-      this.pulumiDir = path.join(__dirname, 'utils', 'pulumi');
+      this.pulumiDir = os.homedir();
       this.pulumiHome = path.join(this.pulumiDir, '.pulumi');
       this.pulumiBin = path.join(this.pulumiHome, 'bin');
       this.pulumiPath = path.join(this.pulumiBin, 'pulumi');
 
       if (!fse.pathExistsSync(this.pulumiPath)) {
-        shell.exec(`node ${path.join(this.pulumiDir, 'install.js')}`);
+        shell.exec(`node ${PULUMI_INSTALL_FILE_PATH}`);
       }
       this.pulumiAlreadyExists = false;
     }
@@ -247,7 +248,7 @@ export default class PulumiComponent {
     }
   }
 
-  async up(inputs): Promise<string> {
+  async up(inputs): Promise<any> {
     const {
       credentials,
       cloudPlatform,
@@ -284,10 +285,13 @@ export default class PulumiComponent {
     // const his = await stack.history();
     // const output = await stack.outputs();
 
-    return upRes.stdout;
+    return {
+      stdout: upRes.stdout,
+      stderr: upRes.stderr,
+    };
   }
 
-  async destroy(inputs): Promise<string> {
+  async destroy(inputs): Promise<any> {
     const {
       credentials,
       cloudPlatform,
@@ -323,7 +327,10 @@ export default class PulumiComponent {
     const destroyRes = await stack.destroy({ onOutput: console.log });
     // await stack.workspace.removeStack(stackName);
 
-    return destroyRes.stdout;
+    return {
+      stdout: destroyRes.stdout,
+      stderr: destroyRes.stderr,
+    };
   }
 
 

--- a/src/utils/pulumi/install.ts
+++ b/src/utils/pulumi/install.ts
@@ -3,27 +3,29 @@ import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as rimraf from 'rimraf';
 import { Logger, downloadRequest } from '@serverless-devs/core';
+import * as os from 'os';
 
 const VERSION = '2.21.2';
 
 async function install() {
   // 判断 pulumi 是否存在
   if (commandExists.sync('pulumi')) {
-    Logger.log('pulumi exist!');
+    Logger.log('pulumi exist!', 'green');
     return;
   }
   // 判断平台
   if (process.platform === 'win32' && process.arch === 'x64') {
-    Logger.log('Windows not supported now!Please install it manually.', 'red');
+    Logger.error('PULUMI_INSTALL_ERROR', 'Windows not supported now!Please install it manually.');
   } else if ((process.platform === 'darwin' || process.platform === 'linux') && process.arch === 'x64') {
     // const tarballUrl = `https://get.pulumi.com/releases/sdk/pulumi-v${VERSION}-${process.platform}-x64.tar.gz`;
-    const tarballUrl = 'https://serverless-tool.oss-cn-hangzhou.aliyuncs.com/others/pulumi-alibaba-component/pulumi-v2.21.2-darwin-x64.tar.gz?versionId=CAEQFRiBgMDVj_LWvxciIGY3YmZiMDMxMzNlNTQ2ZDk4M2Q2MzcyN2YzYTNiM2M5';
+    const tarballUrl = `https://serverless-tool.oss-cn-hangzhou.aliyuncs.com/others/pulumi-alibaba-component/pulumi-v${VERSION}-darwin-x64.tar.gz?versionId=CAEQFRiBgMDVj_LWvxciIGY3YmZiMDMxMzNlNTQ2ZDk4M2Q2MzcyN2YzYTNiM2M5`;
     const dest = path.join(__dirname, 'pulumi.tar.gz');
     if (await fse.pathExists(dest)) {
       await fse.unlink(dest);
     }
     Logger.log(`Installing Pulumi v${VERSION} from ${tarballUrl}...`, 'yellow');
-    const pulumiHome = path.join(__dirname, '.pulumi');
+    // const pulumiHome = path.join(os.homedir(), '.pulumiComponent/.pulumi');
+    const pulumiHome = path.join(os.homedir(), '.pulumi');
     const tmpDir = path.join(__dirname, '.pulumiTmp/');
     if (await fse.pathExists(pulumiHome)) { rimraf.sync(pulumiHome); }
     if (await fse.pathExists(tmpDir)) { rimraf.sync(tmpDir); }
@@ -44,7 +46,7 @@ async function install() {
 
     rimraf.sync(tmpDir);
   } else {
-    Logger.log("We're sorry, but it looks like Pulumi is not supported on your platform! More infomation please refer to https://github.com/pulumi/pulumi", 'red');
+    Logger.error('PULUMI_INSTALL_ERROR', "We're sorry, but it looks like Pulumi is not supported on your platform! More infomation please refer to https://github.com/pulumi/pulumi");
   }
 }
 


### PR DESCRIPTION
将 up 和 destroy 方法的返回更改为结构体 {stdout: , stderr};

将 pulumiHome 目录更改为全局路径： ~/.pulumi，这样能够避免两个 project 操作相同 stack 时，出现错误，同时 pulumi 版本更新不会影响已有的 stack 等资源。